### PR TITLE
Fix CRYOWRF 2D fields, grid spacing, performance, and config flexibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Follow these steps in order to produce PGW WRF/CRYOWRF boundary conditions.
 3. Convert ERA5 GRIB files to NetCDF:
 
    ```bash
-   python scripts/grib2netcdf.py --config my_experiment.toml
+   python scripts/grib2netcdf.py --config my_experiment.toml --profile wrf
    ```
 
 ### Step 2 — Download and Prepare CMIP6 Data

--- a/pgw4era.toml
+++ b/pgw4era.toml
@@ -3,11 +3,14 @@
 
 [wrf]
 # Paths
+# grib_input_pattern = "ERA5_grb/3hr/era5_daily_*_2009060?.grb"  # glob for grib2netcdf.py
+# grib_output_dir    = "ERA5_netcdf"                              # output dir for grib2netcdf.py
 ERA5netcdf_dir = "/data/ERA5/ERA5_netcdf/"
 ERA5_sfc_ref_file = "era5_daily_sfc_20090601.nc"
 ERA5_pl_ref_file = "./era5_plev.nc"
 CMIP6_monthly_dir = "/data/CMIP6/"
 CMIP6anom_dir = "/data/CMIP6/"
+# CMIP6ensemble_dir = "/data/CMIP6/ensemble_mean"  # output dir for Create_CMIP6_AnnualCycleChange_ENSMEAN.py (default: current working dir)
 figs_path = "/data/CMIP6/Figs"
 
 # Time range to generate boundary conditions for
@@ -29,6 +32,8 @@ variables_3d = ["ta", "ua", "va", "zg", "hur"]
 
 [cryowrf]
 # Paths (same structure as wrf; adjust as needed)
+# grib_input_pattern = "ERA5_grb/3hr/era5_daily_*_2009060?.grb"  # glob for grib2netcdf.py
+# grib_output_dir    = "ERA5_netcdf"                              # output dir for grib2netcdf.py
 ERA5netcdf_dir = "/data/ERA5/ERA5_netcdf/"
 ERA5_sfc_ref_file = "era5_daily_sfc_20090601.nc"
 ERA5_pl_ref_file = "./era5_plev.nc"
@@ -56,3 +61,8 @@ variables_3d = ["ta", "ua", "va", "zg", "hur"]
 # CRYOWRF-specific options
 one_timestep_files = false   # set true to produce one output file per timestep
 noahmp = false               # set true to enable NoahMP land-surface fields
+# output_dir = "/path/to/output"  # directory for WRF intermediate files (default: current dir)
+# sday = 1    # start day within smonth (default: 1)
+# eday = 30   # end day within emonth (default: last day of emonth)
+# ERA5_pl_pattern  = "era5_daily_pl_%Y%m%d.nc"   # strftime pattern for pressure-level files
+# ERA5_sfc_pattern = "era5_daily_sfc_%Y%m%d.nc"  # strftime pattern for surface files

--- a/pgw4era/config.py
+++ b/pgw4era/config.py
@@ -82,7 +82,15 @@ def load_config(path: str | Path, profile: str) -> SimpleNamespace:
 
     # Derived helpers
     cfg.setdefault("models", None)
+    cfg.setdefault("vars2d_invarERA5", [])
     cfg.setdefault("figs_path", None)
+    cfg.setdefault("CMIP6ensemble_dir", None)
+    cfg.setdefault("output_dir", None)
+    cfg.setdefault("sday", 1)
+    cfg.setdefault("eday", None)
+    cfg.setdefault("ERA5_pl_pattern", "era5_daily_pl_%Y%m%d.nc")
+    cfg.setdefault("ERA5_sfc_pattern", "era5_daily_sfc_%Y%m%d.nc")
+    cfg.setdefault("reverse", False)
     cfg["variables_all"] = cfg["variables_2d"] + cfg["variables_3d"]
     periods = cfg["periods"]
     cfg["syearp"] = periods[0][0]

--- a/pgw4era/cryowrf/outputInter_CRYOWRF.f90
+++ b/pgw4era/cryowrf/outputInter_CRYOWRF.f90
@@ -50,9 +50,9 @@ character (len=9) :: field ! Name of the field
 character (len=24) :: hdate ! Valid date for data YYYY:MM:DD_HH:00:00
 character (len=25) :: units ! Units of data
 character (len=46) :: desc ! Short description of data
-character (len=46) :: fields3d_desc(5),fields2d_desc(9)
-character (len=25) :: fields3d_units(5),fields2d_units(9)
-character (len=9)  :: fields3d_name(5), fields2d_name(9)
+character (len=46) :: fields3d_desc(5),fields2d_desc(21)
+character (len=25) :: fields3d_units(5),fields2d_units(21)
+character (len=9)  :: fields3d_name(5), fields2d_name(21)
 
 
 integer :: ounit !output file
@@ -92,6 +92,18 @@ fields2d_name(6) = 'TT       '
 fields2d_name(7) = 'SKINTEMP '
 fields2d_name(8) = 'SNOW     '
 fields2d_name(9) = 'SNOWH    '
+fields2d_name(10) = 'SST      '
+fields2d_name(11) = 'SEAICE   '
+fields2d_name(12) = 'ST000007 '
+fields2d_name(13) = 'ST007028 '
+fields2d_name(14) = 'ST028100 '
+fields2d_name(15) = 'ST100289 '
+fields2d_name(16) = 'SM000007 '
+fields2d_name(17) = 'SM007028 '
+fields2d_name(18) = 'SM028100 '
+fields2d_name(19) = 'SM100289 '
+fields2d_name(20) = 'SOILHGT  '
+fields2d_name(21) = 'LANDSEA  '
 
 fields2d_units(1) = 'm s-1                    '
 fields2d_units(2) = 'm s-1                    '
@@ -102,6 +114,18 @@ fields2d_units(6) = 'K                        '
 fields2d_units(7) = 'K                        '
 fields2d_units(8) = 'kg m-2                   '
 fields2d_units(9) = 'm                        '
+fields2d_units(10) = 'K                        '
+fields2d_units(11) = 'fraction (0 - 1)         '
+fields2d_units(12) = 'K                        '
+fields2d_units(13) = 'K                        '
+fields2d_units(14) = 'K                        '
+fields2d_units(15) = 'K                        '
+fields2d_units(16) = 'm3 m-3                   '
+fields2d_units(17) = 'm3 m-3                   '
+fields2d_units(18) = 'm3 m-3                   '
+fields2d_units(19) = 'm3 m-3                   '
+fields2d_units(20) = 'm                        '
+fields2d_units(21) = '0/1 Flag                 '
 
 fields2d_desc(1) = 'U                                           '
 fields2d_desc(2) = 'V                                           '
@@ -109,9 +133,21 @@ fields2d_desc(3) = 'Relative Humidity                           '
 fields2d_desc(4) = 'Surface Pressure                            '
 fields2d_desc(5) = 'Sea-level pressure                          '
 fields2d_desc(6) = 'Temperature                                 '
-fields2d_desc(7) = 'Sea-Surface Temperature                     '
+fields2d_desc(7) = 'Surface Temperature                         '
 fields2d_desc(8) = 'Water equivalent snow depth                 '
 fields2d_desc(9) = 'Physical snow depth                         '
+fields2d_desc(10) = 'Sea-Surface Temperature                     '
+fields2d_desc(11) = 'Sea Ice Concentration                       '
+fields2d_desc(12) = 'Soil Temperature level 1                    '
+fields2d_desc(13) = 'Soil Temperature level 2                    '
+fields2d_desc(14) = 'Soil Temperature level 3                    '
+fields2d_desc(15) = 'Soil Temperature level 4                    '
+fields2d_desc(16) = 'Soil Moisture level 1                       '
+fields2d_desc(17) = 'Soil Moisture level 2                       '
+fields2d_desc(18) = 'Soil Moisture level 3                       '
+fields2d_desc(19) = 'Soil Moisture level 4                       '
+fields2d_desc(20) = 'Surface height                              '
+fields2d_desc(21) = 'Land-Sea mask                               '
 
 
 
@@ -160,7 +196,6 @@ end do
 do nf = 1,nfields2d
 
   xlvl = 200100.0
-  if (fields2d_name(nf).eq.'PMSL') xlvl=201300.0
   field = fields2d_name(nf)
   units = fields2d_units(nf)
   desc  = fields2d_desc(nf)

--- a/pgw4era/cryowrf/write_intermediate.py
+++ b/pgw4era/cryowrf/write_intermediate.py
@@ -19,8 +19,12 @@ Authors: Daniel Argüeso, CRYOWRF integration
 
 from __future__ import annotations
 
+import calendar
 import datetime as dt
+import os
 import sys
+
+import xarray as xr
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -51,6 +55,20 @@ except ImportError as exc:
 # Variable mappings
 # ---------------------------------------------------------------------------
 VARS3D_CODES: dict[str, str] = {"hur": "r", "ta": "t", "ua": "u", "va": "v", "zg": "z"}
+# ERA5 variable names for soil/terrain/mask fields written without PGW anomaly
+VARS2D_INVAR_CODES: dict[str, str] = {
+    "stl1": "stl1",   # soil temperature 0-7 cm   → ST000007
+    "stl2": "stl2",   # soil temperature 7-28 cm  → ST007028
+    "stl3": "stl3",   # soil temperature 28-100 cm → ST028100
+    "stl4": "stl4",   # soil temperature 100-289 cm → ST100289
+    "swvl1": "swvl1", # soil moisture 0-7 cm      → SM000007
+    "swvl2": "swvl2", # soil moisture 7-28 cm     → SM007028
+    "swvl3": "swvl3", # soil moisture 28-100 cm   → SM028100
+    "swvl4": "swvl4", # soil moisture 100-289 cm  → SM100289
+    "z": "z",         # surface geopotential ÷ 9.81 → SOILHGT (m)
+    "lsm": "lsm",     # land-sea mask              → LANDSEA
+}
+
 VARS2D_CODES: dict[str, str] = {
     "dew": "d2m",
     "tas": "t2m",
@@ -61,6 +79,8 @@ VARS2D_CODES: dict[str, str] = {
     "ts": "skt",
     "sd": "sd",  # snow depth (water equivalent) — ERA5 field name
     "rsn": "rsn",  # snow density for physical depth calculation
+    "tos": "sst",  # sea-surface temperature
+    "siconc": "siconc",  # sea-ice area fraction
 }
 
 PLVS: list[float] = [
@@ -103,8 +123,9 @@ PLVS: list[float] = [
     100.00,
 ]
 
-# CRYOWRF uses 9 2-D fields (7 standard + SNOW + SNOWH)
-_N2D = 9
+# CRYOWRF uses 21 2-D fields: 7 standard + SNOW + SNOWH + SST + SEAICE
+#   + 4 soil temp + 4 soil moisture + SOILHGT + LANDSEA
+_N2D = 21
 _RHO_WATER = 1000.0  # kg/m³, used to convert snow depth to physical depth
 
 
@@ -133,12 +154,18 @@ def run(cfg: SimpleNamespace, overwrite_file: bool = False, create_figs: bool = 
     vars3d = cfg.variables_3d
     vars2d = cfg.variables_2d
     nfields3d = len(vars3d)
+    _anom_sign = -1.0 if getattr(cfg, "reverse", False) else 1.0
 
-    CMIP6anom_dir = cfg.CMIP6anom_dir
-    ERA5_dir = cfg.ERA5netcdf_dir
+    ERA5_dir = os.path.abspath(cfg.ERA5netcdf_dir)
+    ensemble_dir = os.path.abspath(cfg.CMIP6ensemble_dir or cfg.CMIP6anom_dir)
+
+    output_dir = cfg.output_dir
+    if output_dir:
+        os.makedirs(output_dir, exist_ok=True)
+        os.chdir(output_dir)
 
     # Reference grid from ERA5 surface file
-    file_ref = nc.Dataset(f"{cfg.ERA5netcdf_dir}/{cfg.ERA5_sfc_ref_file}")
+    file_ref = nc.Dataset(f"{ERA5_dir}/{cfg.ERA5_sfc_ref_file}")
     lat = file_ref.variables["latitude"][:]
     lon = file_ref.variables["longitude"][:]
     file_ref.close()
@@ -146,15 +173,54 @@ def run(cfg: SimpleNamespace, overwrite_file: bool = False, create_figs: bool = 
     nlon = len(lon)
     nlat = len(lat)
 
-    year, month, day = syear, smonth, 1
+    startlat = float(lat[0])
+    startlon = float(lon[0])
+    deltalon = float(lon[1] - lon[0])
+    deltalat = float(lat[1] - lat[0])
 
-    while year < eyear or (year == eyear and month < emonth):
+    sday = cfg.sday
+    eday = cfg.eday or calendar.monthrange(eyear, emonth)[1]
+    ERA5_pl_pattern = cfg.ERA5_pl_pattern
+    ERA5_sfc_pattern = cfg.ERA5_sfc_pattern
+
+    def _interp_anom(path, varname):
+        """Load anomaly file and interpolate to ERA5 lat/lon grid."""
+        with xr.open_dataset(path) as _ds:
+            _da = _ds[varname]
+            _lat_dim = next(d for d in _da.dims if "lat" in d.lower())
+            _lon_dim = next(d for d in _da.dims if "lon" in d.lower())
+            return _da.interp({_lat_dim: lat, _lon_dim: lon}, method="linear").values
+
+    print("Pre-loading anomaly files and interpolating to ERA5 grid...")
+    anom_cache_3d: dict[str, np.ndarray] = {}
+    for _var in vars3d:
+        _path = (
+            f"{ensemble_dir}/interp_plevs/{_var}_{syearp}-{eyearp}_{syearf}-{eyearf}"
+            f"_{experiments[0]}-{experiments[1]}_CC_signal_pinterp.nc"
+        )
+        anom_cache_3d[_var] = _interp_anom(_path, _var)
+        print(f"  loaded 3D anom: {_var} shape={anom_cache_3d[_var].shape}")
+
+    anom_cache_2d: dict[str, np.ndarray] = {}
+    for _var in vars2d:
+        _path = (
+            f"{ensemble_dir}/{_var}_{syearp}-{eyearp}_{syearf}-{eyearf}"
+            f"_{experiments[0]}-{experiments[1]}_CC_signal.nc"
+        )
+        anom_cache_2d[_var] = _interp_anom(_path, _var)
+        print(f"  loaded 2D anom: {_var} shape={anom_cache_2d[_var].shape}")
+
+    current_date = dt.datetime(syear, smonth, sday)
+    loop_end = dt.datetime(eyear, emonth, eday)
+
+    while current_date <= loop_end:
+        year, month, day = current_date.year, current_date.month, current_date.day
         midmonth = calc_midmonth(year)
 
         print(f"processing year {year} month {month:02d} day {day:02d}")
 
-        ferapl = nc.Dataset(f"{ERA5_dir}/era5_daily_pl_{year}{month:02d}{day:02d}.nc", "r")
-        ferasfc = nc.Dataset(f"{ERA5_dir}/era5_daily_sfc_{year}{month:02d}{day:02d}.nc", "r")
+        ferapl = nc.Dataset(f"{ERA5_dir}/{current_date.strftime(ERA5_pl_pattern)}", "r")
+        ferasfc = nc.Dataset(f"{ERA5_dir}/{current_date.strftime(ERA5_sfc_pattern)}", "r")
 
         date_init = dt.datetime(year, month, day, 0)
         date_end = dt.datetime(year, month, day, 21)
@@ -175,6 +241,7 @@ def run(cfg: SimpleNamespace, overwrite_file: bool = False, create_figs: bool = 
             file_out = "ERA5:" + filedate.split("_")[0] + "_" + filedate.split("_")[1].split("-")[0]
             filewrite = checkfile(file_out, overwrite_file)
             if filewrite:
+
                 tdelta = np.asarray(
                     [(midmonth[i] - proc_date).total_seconds() for i in range(len(midmonth))]
                 )
@@ -197,11 +264,6 @@ def run(cfg: SimpleNamespace, overwrite_file: bool = False, create_figs: bool = 
                 # --- 3-D variables ---
                 for var in vars3d:
                     print(f"Processing variable {var}")
-                    fanom = nc.Dataset(
-                        f"{CMIP6anom_dir}/{var}_{syearp}-{eyearp}_{syearf}-{eyearf}"
-                        f"_{experiments[0]}-{experiments[1]}_CC_signal_pinterp.nc"
-                    )
-
                     if np.all(np.diff(ferapl.variables["level"][:]) > 0):
                         var_era = ferapl.variables[VARS3D_CODES[var]][nt, ::-1, :, :]
                     else:
@@ -211,75 +273,96 @@ def run(cfg: SimpleNamespace, overwrite_file: bool = False, create_figs: bool = 
                         var_era = var_era / 9.81
 
                     if np.argmin(np.abs(tdelta)) == 0:
-                        var_anom = fanom.variables[var][i1, ::-1, :, :]
+                        var_anom = anom_cache_3d[var][i1, ::-1, :, :]
                     else:
-                        var_anom_1 = fanom.variables[var][i1, ::-1, :, :]
-                        var_anom_2 = fanom.variables[var][i2, ::-1, :, :]
+                        var_anom_1 = anom_cache_3d[var][i1, ::-1, :, :]
+                        var_anom_2 = anom_cache_3d[var][i2, ::-1, :, :]
                         var_anom = (
                             var_anom_1
                             + (var_anom_2 - var_anom_1) * tdelta_before / tdelta_mid_month
                         )
 
-                    temp = var_era + np.nan_to_num(var_anom)
+                    temp = var_era + np.nan_to_num(_anom_sign * var_anom)
                     if var == "hur":
                         temp = np.clip(temp, 0, 100)
                     vout[var] = temp
-                    fanom.close()
 
                 # --- 2-D variables ---
                 for var in vars2d:
+                    if var not in VARS2D_CODES and var != "hurs":
+                        print(f"  WARNING: {var} has no ERA5 surface mapping — skipping")
+                        continue
                     print(f"Processing variable {var}")
                     if var == "hurs":
                         dew_era = ferasfc.variables[VARS2D_CODES["dew"]][nt, :, :] - const.tkelvin
                         tas_era = ferasfc.variables[VARS2D_CODES["tas"]][nt, :, :] - const.tkelvin
                         var_era = calc_relhum(dew_era, tas_era)
+                    elif var == "siconc":
+                        # ERA5 siconc is fraction (0-1); CMIP6 anomaly is in % (0-100)
+                        var_era = ferasfc.variables[VARS2D_CODES[var]][nt, :, :] * 100.0
                     else:
                         var_era = ferasfc.variables[VARS2D_CODES[var]][nt, :, :]
 
-                    fanom = nc.Dataset(
-                        f"{CMIP6anom_dir}/{var}_{syearp}-{eyearp}_{syearf}-{eyearf}"
-                        f"_{experiments[0]}-{experiments[1]}_CC_signal.nc"
-                    )
-
                     if np.min(np.abs(tdelta)) == 0:
-                        var_anom = fanom.variables[var][i1, :, :]
+                        var_anom = anom_cache_2d[var][i1, :, :]
                     else:
-                        var_anom_1 = fanom.variables[var][i1, :, :]
-                        var_anom_2 = fanom.variables[var][i2, :, :]
+                        var_anom_1 = anom_cache_2d[var][i1, :, :]
+                        var_anom_2 = anom_cache_2d[var][i2, :, :]
                         var_anom = (
                             var_anom_1
                             + (var_anom_2 - var_anom_1) * tdelta_before / tdelta_mid_month
                         )
 
-                    vout[var] = var_era + np.nan_to_num(var_anom)
-                    fanom.close()
+                    result = np.array(var_era, dtype="float64") + np.nan_to_num(_anom_sign * var_anom)
+
+                    if var == "siconc":
+                        result = np.clip(result, 0.0, 100.0)
+                    elif var == "tos":
+                        # ERA5 sst is masked over land; restore those cells to avoid fill-value
+                        # artefacts at the Antarctic coastline when stripped by np.float32()
+                        if isinstance(var_era, np.ma.MaskedArray):
+                            land = np.ma.getmaskarray(var_era)
+                            if land.any():
+                                result[land] = var_era.data[land]
+
+                    vout[var] = result
 
                 # --- CRYOWRF snow fields ---
-                # Snow water equivalent (kg/m²)
                 if "sd" in ferasfc.variables:
-                    snow_we = ferasfc.variables["sd"][nt, :, :]  # m of water equiv.
-                    snow_we = snow_we * _RHO_WATER  # convert to kg/m²
+                    snow_we = ferasfc.variables["sd"][nt, :, :] * _RHO_WATER
                 else:
                     snow_we = np.zeros((nlat, nlon), dtype="float32")
 
-                # Physical snow depth (m): sd [m water] * rho_water / rho_snow
-                # ERA5 provides snow density (rsn, kg/m³); fall back to 300 kg/m³
                 if "rsn" in ferasfc.variables:
                     rho_snow = ferasfc.variables["rsn"][nt, :, :]
                     rho_snow = np.where(rho_snow > 0, rho_snow, 300.0)
                 else:
                     rho_snow = np.full((nlat, nlon), 300.0, dtype="float32")
 
-                snow_depth = snow_we / rho_snow  # physical depth in m
+                snow_depth = snow_we / rho_snow
 
-                # --- Write CRYOWRF intermediate format ---
+                # --- ERA5-only fields (no PGW anomaly): soil, terrain, land mask ---
+                def _read_invar(era5_name: str, fallback: float) -> np.ndarray:
+                    if era5_name in ferasfc.variables:
+                        raw = ferasfc.variables[era5_name]
+                        data = raw[nt, :, :] if raw.ndim == 3 else raw[:, :]
+                        return np.array(data, dtype="float32")
+                    return np.full((nlat, nlon), fallback, dtype="float32")
+
+                stl1 = _read_invar("stl1", 273.15)
+                stl2 = _read_invar("stl2", 273.15)
+                stl3 = _read_invar("stl3", 273.15)
+                stl4 = _read_invar("stl4", 273.15)
+                swvl1 = _read_invar("swvl1", 0.0)
+                swvl2 = _read_invar("swvl2", 0.0)
+                swvl3 = _read_invar("swvl3", 0.0)
+                swvl4 = _read_invar("swvl4", 0.0)
+                soilhgt = _read_invar("z", 0.0) / 9.81  # geopotential → height (m)
+                landsea = _read_invar("lsm", 0.0)
+
+                # --- Write CRYOWRF intermediate format (append all timesteps to daily file) ---
                 fields3d = np.ndarray(shape=(nfields3d, len(PLVS), nlat, nlon), dtype="float32")
                 fields2d = np.ndarray(shape=(_N2D, nlat, nlon), dtype="float32")
-
-                startlat = float(lat[0])
-                startlon = float(lon[0])
-                deltalon = 0.30
-                deltalat = -0.30
 
                 fields3d[0] = np.float32(vout["hur"])
                 fields3d[1] = np.float32(vout["ta"])
@@ -296,6 +379,18 @@ def run(cfg: SimpleNamespace, overwrite_file: bool = False, create_figs: bool = 
                 fields2d[6] = np.float32(vout["ts"])
                 fields2d[7] = np.float32(snow_we)
                 fields2d[8] = np.float32(snow_depth)
+                fields2d[9] = np.float32(vout["tos"])
+                fields2d[10] = np.float32(vout["siconc"] / 100.0)  # fraction (0-1) for WRF
+                fields2d[11] = stl1
+                fields2d[12] = stl2
+                fields2d[13] = stl3
+                fields2d[14] = stl4
+                fields2d[15] = swvl1
+                fields2d[16] = swvl2
+                fields2d[17] = swvl3
+                fields2d[18] = swvl4
+                fields2d[19] = soilhgt
+                fields2d[20] = landsea
 
                 f90.writeint(
                     PLVS,
@@ -313,5 +408,4 @@ def run(cfg: SimpleNamespace, overwrite_file: bool = False, create_figs: bool = 
         ferapl.close()
         ferasfc.close()
 
-        end_date = dt.datetime(year, month, day) + dt.timedelta(days=1)
-        year, month, day = end_date.year, end_date.month, end_date.day
+        current_date += dt.timedelta(days=1)

--- a/pgw4era/cryowrf/write_intermediate_onetimestep.py
+++ b/pgw4era/cryowrf/write_intermediate_onetimestep.py
@@ -14,8 +14,12 @@ standard CRYOWRF variant.
 
 from __future__ import annotations
 
+import calendar
 import datetime as dt
+import os
 from types import SimpleNamespace
+
+import xarray as xr
 
 import netCDF4 as nc
 import numpy as np
@@ -62,11 +66,17 @@ def run(cfg: SimpleNamespace, overwrite_file: bool = False, create_figs: bool = 
     vars3d = cfg.variables_3d
     vars2d = cfg.variables_2d
     nfields3d = len(vars3d)
+    _anom_sign = -1.0 if getattr(cfg, "reverse", False) else 1.0
 
-    CMIP6anom_dir = cfg.CMIP6anom_dir
-    ERA5_dir = cfg.ERA5netcdf_dir
+    ERA5_dir = os.path.abspath(cfg.ERA5netcdf_dir)
+    ensemble_dir = os.path.abspath(cfg.CMIP6ensemble_dir or cfg.CMIP6anom_dir)
 
-    file_ref = nc.Dataset(f"{cfg.ERA5netcdf_dir}/{cfg.ERA5_sfc_ref_file}")
+    output_dir = cfg.output_dir
+    if output_dir:
+        os.makedirs(output_dir, exist_ok=True)
+        os.chdir(output_dir)
+
+    file_ref = nc.Dataset(f"{ERA5_dir}/{cfg.ERA5_sfc_ref_file}")
     lat = file_ref.variables["latitude"][:]
     lon = file_ref.variables["longitude"][:]
     file_ref.close()
@@ -74,15 +84,54 @@ def run(cfg: SimpleNamespace, overwrite_file: bool = False, create_figs: bool = 
     nlon = len(lon)
     nlat = len(lat)
 
-    year, month, day = syear, smonth, 1
+    startlat = float(lat[0])
+    startlon = float(lon[0])
+    deltalon = float(lon[1] - lon[0])
+    deltalat = float(lat[1] - lat[0])
 
-    while year < eyear or (year == eyear and month < emonth):
+    sday = cfg.sday
+    eday = cfg.eday or calendar.monthrange(eyear, emonth)[1]
+    ERA5_pl_pattern = cfg.ERA5_pl_pattern
+    ERA5_sfc_pattern = cfg.ERA5_sfc_pattern
+
+    def _interp_anom(path, varname):
+        """Load anomaly file and interpolate to ERA5 lat/lon grid."""
+        with xr.open_dataset(path) as _ds:
+            _da = _ds[varname]
+            _lat_dim = next(d for d in _da.dims if "lat" in d.lower())
+            _lon_dim = next(d for d in _da.dims if "lon" in d.lower())
+            return _da.interp({_lat_dim: lat, _lon_dim: lon}, method="linear").values
+
+    print("Pre-loading anomaly files and interpolating to ERA5 grid...")
+    anom_cache_3d: dict[str, np.ndarray] = {}
+    for _var in vars3d:
+        _path = (
+            f"{ensemble_dir}/interp_plevs/{_var}_{syearp}-{eyearp}_{syearf}-{eyearf}"
+            f"_{experiments[0]}-{experiments[1]}_CC_signal_pinterp.nc"
+        )
+        anom_cache_3d[_var] = _interp_anom(_path, _var)
+        print(f"  loaded 3D anom: {_var} shape={anom_cache_3d[_var].shape}")
+
+    anom_cache_2d: dict[str, np.ndarray] = {}
+    for _var in vars2d:
+        _path = (
+            f"{ensemble_dir}/{_var}_{syearp}-{eyearp}_{syearf}-{eyearf}"
+            f"_{experiments[0]}-{experiments[1]}_CC_signal.nc"
+        )
+        anom_cache_2d[_var] = _interp_anom(_path, _var)
+        print(f"  loaded 2D anom: {_var} shape={anom_cache_2d[_var].shape}")
+
+    current_date = dt.datetime(syear, smonth, sday)
+    loop_end = dt.datetime(eyear, emonth, eday)
+
+    while current_date <= loop_end:
+        year, month, day = current_date.year, current_date.month, current_date.day
         midmonth = calc_midmonth(year)
 
         print(f"processing year {year} month {month:02d} day {day:02d}")
 
-        ferapl = nc.Dataset(f"{ERA5_dir}/era5_daily_pl_{year}{month:02d}{day:02d}.nc", "r")
-        ferasfc = nc.Dataset(f"{ERA5_dir}/era5_daily_sfc_{year}{month:02d}{day:02d}.nc", "r")
+        ferapl = nc.Dataset(f"{ERA5_dir}/{current_date.strftime(ERA5_pl_pattern)}", "r")
+        ferasfc = nc.Dataset(f"{ERA5_dir}/{current_date.strftime(ERA5_sfc_pattern)}", "r")
 
         date_init = dt.datetime(year, month, day, 0)
         date_end = dt.datetime(year, month, day, 21)
@@ -120,10 +169,6 @@ def run(cfg: SimpleNamespace, overwrite_file: bool = False, create_figs: bool = 
                 tdelta_mid_month = (midmonth[tdelta_min] - midmonth[tdelta_min - 1]).total_seconds()
 
             for var in vars3d:
-                fanom = nc.Dataset(
-                    f"{CMIP6anom_dir}/{var}_{syearp}-{eyearp}_{syearf}-{eyearf}"
-                    f"_{experiments[0]}-{experiments[1]}_CC_signal_pinterp.nc"
-                )
                 if np.all(np.diff(ferapl.variables["level"][:]) > 0):
                     var_era = ferapl.variables[VARS3D_CODES[var]][nt, ::-1, :, :]
                 else:
@@ -133,43 +178,55 @@ def run(cfg: SimpleNamespace, overwrite_file: bool = False, create_figs: bool = 
                     var_era = var_era / 9.81
 
                 if np.argmin(np.abs(tdelta)) == 0:
-                    var_anom = fanom.variables[var][i1, ::-1, :, :]
+                    var_anom = anom_cache_3d[var][i1, ::-1, :, :]
                 else:
-                    var_anom_1 = fanom.variables[var][i1, ::-1, :, :]
-                    var_anom_2 = fanom.variables[var][i2, ::-1, :, :]
+                    var_anom_1 = anom_cache_3d[var][i1, ::-1, :, :]
+                    var_anom_2 = anom_cache_3d[var][i2, ::-1, :, :]
                     var_anom = (
                         var_anom_1 + (var_anom_2 - var_anom_1) * tdelta_before / tdelta_mid_month
                     )
 
-                temp = var_era + np.nan_to_num(var_anom)
+                temp = var_era + np.nan_to_num(_anom_sign * var_anom)
                 if var == "hur":
                     temp = np.clip(temp, 0, 100)
                 vout[var] = temp
-                fanom.close()
 
             for var in vars2d:
+                if var not in VARS2D_CODES and var != "hurs":
+                    print(f"  WARNING: {var} has no ERA5 surface mapping — skipping")
+                    continue
                 if var == "hurs":
                     dew_era = ferasfc.variables[VARS2D_CODES["dew"]][nt, :, :] - const.tkelvin
                     tas_era = ferasfc.variables[VARS2D_CODES["tas"]][nt, :, :] - const.tkelvin
                     var_era = calc_relhum(dew_era, tas_era)
+                elif var == "siconc":
+                    # ERA5 siconc is fraction (0-1); CMIP6 anomaly is in % (0-100)
+                    var_era = ferasfc.variables[VARS2D_CODES[var]][nt, :, :] * 100.0
                 else:
                     var_era = ferasfc.variables[VARS2D_CODES[var]][nt, :, :]
 
-                fanom = nc.Dataset(
-                    f"{CMIP6anom_dir}/{var}_{syearp}-{eyearp}_{syearf}-{eyearf}"
-                    f"_{experiments[0]}-{experiments[1]}_CC_signal.nc"
-                )
                 if np.min(np.abs(tdelta)) == 0:
-                    var_anom = fanom.variables[var][i1, :, :]
+                    var_anom = anom_cache_2d[var][i1, :, :]
                 else:
-                    var_anom_1 = fanom.variables[var][i1, :, :]
-                    var_anom_2 = fanom.variables[var][i2, :, :]
+                    var_anom_1 = anom_cache_2d[var][i1, :, :]
+                    var_anom_2 = anom_cache_2d[var][i2, :, :]
                     var_anom = (
                         var_anom_1 + (var_anom_2 - var_anom_1) * tdelta_before / tdelta_mid_month
                     )
 
-                vout[var] = var_era + np.nan_to_num(var_anom)
-                fanom.close()
+                result = np.array(var_era, dtype="float64") + np.nan_to_num(_anom_sign * var_anom)
+
+                if var == "siconc":
+                    result = np.clip(result, 0.0, 100.0)
+                elif var == "tos":
+                    # ERA5 sst is masked over land; restore those cells to avoid fill-value
+                    # artefacts at the Antarctic coastline when stripped by np.float32()
+                    if isinstance(var_era, np.ma.MaskedArray):
+                        land = np.ma.getmaskarray(var_era)
+                        if land.any():
+                            result[land] = var_era.data[land]
+
+                vout[var] = result
 
             # Snow fields
             if "sd" in ferasfc.variables:
@@ -185,13 +242,27 @@ def run(cfg: SimpleNamespace, overwrite_file: bool = False, create_figs: bool = 
 
             snow_depth = snow_we / rho_snow
 
+            # --- ERA5-only fields (no PGW anomaly): soil, terrain, land mask ---
+            def _read_invar(era5_name: str, fallback: float) -> np.ndarray:
+                if era5_name in ferasfc.variables:
+                    raw = ferasfc.variables[era5_name]
+                    data = raw[nt, :, :] if raw.ndim == 3 else raw[:, :]
+                    return np.array(data, dtype="float32")
+                return np.full((nlat, nlon), fallback, dtype="float32")
+
+            stl1 = _read_invar("stl1", 273.15)
+            stl2 = _read_invar("stl2", 273.15)
+            stl3 = _read_invar("stl3", 273.15)
+            stl4 = _read_invar("stl4", 273.15)
+            swvl1 = _read_invar("swvl1", 0.0)
+            swvl2 = _read_invar("swvl2", 0.0)
+            swvl3 = _read_invar("swvl3", 0.0)
+            swvl4 = _read_invar("swvl4", 0.0)
+            soilhgt = _read_invar("z", 0.0) / 9.81  # geopotential → height (m)
+            landsea = _read_invar("lsm", 0.0)
+
             fields3d = np.ndarray(shape=(nfields3d, len(PLVS), nlat, nlon), dtype="float32")
             fields2d = np.ndarray(shape=(_N2D, nlat, nlon), dtype="float32")
-
-            startlat = float(lat[0])
-            startlon = float(lon[0])
-            deltalon = 0.30
-            deltalat = -0.30
 
             fields3d[0] = np.float32(vout["hur"])
             fields3d[1] = np.float32(vout["ta"])
@@ -208,6 +279,18 @@ def run(cfg: SimpleNamespace, overwrite_file: bool = False, create_figs: bool = 
             fields2d[6] = np.float32(vout["ts"])
             fields2d[7] = np.float32(snow_we)
             fields2d[8] = np.float32(snow_depth)
+            fields2d[9] = np.float32(vout["tos"])
+            fields2d[10] = np.float32(vout["siconc"] / 100.0)  # fraction (0-1) for WRF
+            fields2d[11] = stl1
+            fields2d[12] = stl2
+            fields2d[13] = stl3
+            fields2d[14] = stl4
+            fields2d[15] = swvl1
+            fields2d[16] = swvl2
+            fields2d[17] = swvl3
+            fields2d[18] = swvl4
+            fields2d[19] = soilhgt
+            fields2d[20] = landsea
 
             # Write one file per timestep
             f90.writeint(
@@ -226,5 +309,4 @@ def run(cfg: SimpleNamespace, overwrite_file: bool = False, create_figs: bool = 
         ferapl.close()
         ferasfc.close()
 
-        end_date = dt.datetime(year, month, day) + dt.timedelta(days=1)
-        year, month, day = end_date.year, end_date.month, end_date.day
+        current_date += dt.timedelta(days=1)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
     { name = "Daniel Argüeso", email = "d.argueso@uib.es" },
 ]
 readme = "README.md"
-requires-python = ">=3.10"
+requires-python = ">=3.9"
 dependencies = [
     "netCDF4",
     "xarray",

--- a/scripts/Calculate_CMIP6_Annual_cycle-CC_change-regrid_ERA5.py
+++ b/scripts/Calculate_CMIP6_Annual_cycle-CC_change-regrid_ERA5.py
@@ -75,7 +75,7 @@ def calculate_annual_cycle(GCM, varname, experiments, syear, eyear, idir, odir):
     if not os.path.isfile(ofname):
         import pandas as pd
 
-        fin_p = finall.sel(time=slice(str(syear), str(eyear)))
+        fin_p = finall.sortby("time").sel(time=slice(str(syear), str(eyear)))
         avail_dates = pd.to_datetime(fin_p.time.values)
         year_months = {(d.year, d.month) for d in avail_dates}
         all_months = {(y, m) for y in range(syear, eyear + 1) for m in range(1, 13)}

--- a/scripts/Create_CMIP6_AnnualCycleChange_ENSMEAN.py
+++ b/scripts/Create_CMIP6_AnnualCycleChange_ENSMEAN.py
@@ -12,6 +12,7 @@ Usage
 from __future__ import annotations
 
 import argparse
+import os
 from glob import glob
 from pathlib import Path
 
@@ -73,6 +74,9 @@ def main() -> None:
     idir = f"{cfg.CMIP6anom_dir}/regrid_ERA5"
     odir = f"{cfg.CMIP6anom_dir}/regrid_ERA5"
     cpdir = f"{cfg.CMIP6anom_dir}/corrected_plevs"
+    ensemble_odir = cfg.CMIP6ensemble_dir
+    if ensemble_odir:
+        Path(ensemble_odir).mkdir(exist_ok=True, parents=True)
 
     plvs = np.asarray(
         [
@@ -139,15 +143,22 @@ def main() -> None:
         if "areacella" in fin.variables:
             fin = fin.drop_vars("areacella")
 
-        fin.to_netcdf(
+        allmodels_fname = (
             f"{varname}_{syearp}-{eyearp}_{syearf}-{eyearf}"
             f"_{'-'.join(experiments)}_CC_signal_allmodels.nc"
         )
+        ensmean_fname = (
+            f"{varname}_{syearp}-{eyearp}_{syearf}-{eyearf}"
+            f"_{'-'.join(experiments)}_CC_signal.nc"
+        )
+        if ensemble_odir:
+            allmodels_fname = os.path.join(ensemble_odir, allmodels_fname)
+            ensmean_fname = os.path.join(ensemble_odir, ensmean_fname)
+
+        fin.to_netcdf(allmodels_fname)
 
         fin_ensmean = mean_with_missing_threshold(fin, dim="model", threshold=1).squeeze()
-        fin_ensmean.to_netcdf(
-            f"{varname}_{syearp}-{eyearp}_{syearf}-{eyearf}_{'-'.join(experiments)}_CC_signal.nc"
-        )
+        fin_ensmean.to_netcdf(ensmean_fname)
 
 
 if __name__ == "__main__":

--- a/scripts/Interpolate_CMIP6_Annual_cycle-CC_pinterp.py
+++ b/scripts/Interpolate_CMIP6_Annual_cycle-CC_pinterp.py
@@ -46,6 +46,7 @@ def main() -> None:
 
     ERA5_pl_ref_file = cfg.ERA5_pl_ref_file
     CMIP6anom_dir = cfg.CMIP6anom_dir
+    ensemble_dir = cfg.CMIP6ensemble_dir or CMIP6anom_dir
     variables = cfg.variables_3d
     experiments = cfg.experiments
     year_ranges = cfg.periods
@@ -55,7 +56,7 @@ def main() -> None:
     era5_ref = xr.open_dataset(ERA5_pl_ref_file)
     era5_plev = era5_ref.plev.values
 
-    interp_dir = f"{CMIP6anom_dir}/interp_plevs"
+    interp_dir = f"{ensemble_dir}/interp_plevs"
     os.makedirs(interp_dir, exist_ok=True)
 
     ctime_i = checkpoint(0)
@@ -68,7 +69,7 @@ def main() -> None:
         )
         if not os.path.exists(out_file):
             fin = xr.open_dataset(
-                f"{CMIP6anom_dir}/{varname}_{syearp}-{eyearp}_{syearf}-{eyearf}"
+                f"{ensemble_dir}/{varname}_{syearp}-{eyearp}_{syearf}-{eyearf}"
                 f"_{'-'.join(experiments)}_CC_signal.nc"
             )
             fin.reindex(plev=fin.plev[::-1])

--- a/scripts/grib2netcdf.py
+++ b/scripts/grib2netcdf.py
@@ -1,18 +1,37 @@
 #!/usr/bin/env python
 """grib2netcdf.py — Convert ERA5 GRIB files to netCDF using grib_to_netcdf.
 
-Edit ``filepatt`` and the output directory to match your data layout.
-
 Usage
 -----
-    python scripts/grib2netcdf.py
+    python scripts/grib2netcdf.py --config my_experiment.toml --profile cryowrf
+
+Optional keys in the chosen config profile:
+    grib_input_pattern  glob for input GRIB files
+                        (default: "ERA5_grb/3hr/era5_daily_*_2009060?.grb")
+    grib_output_dir     output directory for NetCDF files  (default: "ERA5_netcdf")
 """
 
 from __future__ import annotations
 
+import argparse
 import os
 import subprocess
 from glob import glob
+from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:
+    try:
+        import tomli as tomllib  # type: ignore[no-redef]
+    except ModuleNotFoundError as exc:
+        raise ModuleNotFoundError(
+            "Python < 3.11 requires 'tomli' to be installed: pip install tomli"
+        ) from exc
+
+
+_DEFAULT_INPUT_PATTERN = "ERA5_grb/3hr/era5_daily_*_2009060?.grb"
+_DEFAULT_OUTPUT_DIR = "ERA5_netcdf"
 
 
 class bcolors:
@@ -27,23 +46,66 @@ class bcolors:
     UNDERLINE = "\033[4m"
 
 
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Convert ERA5 GRIB files to NetCDF.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--config",
+        default=None,
+        help="Path to the pgw4era TOML configuration file.",
+    )
+    parser.add_argument(
+        "--profile",
+        default="wrf",
+        help="Configuration profile to read (e.g. 'wrf' or 'cryowrf').",
+    )
+    return parser.parse_args()
+
+
+def _load_grib_config(config_path: str | None, profile: str) -> tuple[str, str]:
+    """Return (input_pattern, output_dir) from config or hardcoded defaults."""
+    if config_path is None:
+        return _DEFAULT_INPUT_PATTERN, _DEFAULT_OUTPUT_DIR
+
+    path = Path(config_path)
+    if not path.exists():
+        raise FileNotFoundError(f"Config file not found: {path}")
+
+    with path.open("rb") as fh:
+        data = tomllib.load(fh)
+
+    cfg = data.get(profile, {})
+    input_pattern = cfg.get("grib_input_pattern", _DEFAULT_INPUT_PATTERN)
+    output_dir = cfg.get("grib_output_dir", _DEFAULT_OUTPUT_DIR)
+    return input_pattern, output_dir
+
+
 def main() -> None:
-    filepatt = "ERA5_grb/3hr/era5_daily_*_2009060?.grb"
+    args = parse_args()
+    filepatt, output_dir = _load_grib_config(args.config, args.profile)
+
     files = sorted(glob(filepatt))
     print(f"{bcolors.HEADER}Converting {filepatt} to netCDF{bcolors.ENDC}")
 
+    os.makedirs(output_dir, exist_ok=True)
+
     for fin in files:
-        fout = os.path.basename(fin).split("grb")[0] + "nc"
-        if not os.path.exists(f"ERA5_netcdf/{fout}"):
+        fout = os.path.splitext(os.path.basename(fin))[0] + ".nc"
+        out_path = os.path.join(output_dir, fout)
+        if not os.path.exists(out_path):
             try:
                 subprocess.check_output(
-                    f"grib_to_netcdf -o ERA5_netcdf/{fout} {fin}",
+                    f"grib_to_netcdf -o {out_path} {fin}",
                     shell=True,
+                    stderr=subprocess.STDOUT,
                 )
                 print(f"{bcolors.OKGREEN}Converted {fin} to netCDF{bcolors.ENDC}")
-            except Exception:
+            except subprocess.CalledProcessError as exc:
                 raise SystemExit(
-                    f"{bcolors.ERROR}ERROR: Could not convert {fin} to netCDF{bcolors.ENDC}"
+                    f"{bcolors.ERROR}ERROR: Could not convert {fin} to netCDF\n"
+                    f"{exc.output.decode(errors='replace')}{bcolors.ENDC}"
                 )
         else:
             print(f"{bcolors.OKCYAN}{fin} already converted to netCDF{bcolors.ENDC}")


### PR DESCRIPTION
## Summary

This PR fixes several bugs and adds missing fields to the CRYOWRF intermediate file writer.

### Bug fixes
- **Hardcoded grid spacing**: `deltalon`/`deltalat` were hardcoded to ±0.30° — now derived from the actual ERA5 grid
- **SKINTEMP description**: was incorrectly labelled "Sea-Surface Temperature" in the Fortran writer
- **PMSL xlvl override**: erroneous level override removed from `outputInter_CRYOWRF.f90`
- **Time-ordering**: `Calculate_CMIP6_Annual_cycle` script now calls `.sortby("time")` before `.sel()` to handle unsorted CMIP6 time axes
- **siconc unit scaling**: ERA5 sea-ice fraction (0–1) is now correctly scaled to % before applying the CMIP6 anomaly, then clipped back; result stored as fraction (0–1) for WRF
- **SST land-mask fill values**: masked land cells in ERA5 SST are restored after anomaly addition to avoid artefacts at coastlines

### New fields in CRYOWRF intermediate output
Expanded from 9 to 21 2D fields:
- SST (`tos`) and SEAICE (`siconc`)
- 4 soil temperature layers (ST000007 – ST100289, ERA5 `stl1`–`stl4`)
- 4 soil moisture layers (SM000007 – SM100289, ERA5 `swvl1`–`swvl4`)
- SOILHGT (terrain height from ERA5 geopotential `z`)
- LANDSEA (land-sea mask from ERA5 `lsm`)

### Performance
- All anomaly NetCDF files are now opened, interpolated to the ERA5 grid, and cached **before** the time loop. Previously each variable was opened and closed on every timestep.

### New configuration options (all optional with sensible defaults)
| Key | Description |
|---|---|
| `sday` / `eday` | Start/end day for partial-month runs |
| `output_dir` | Destination directory for WRF intermediate files |
| `ERA5_pl_pattern` / `ERA5_sfc_pattern` | `strftime` filename patterns for ERA5 files |
| `CMIP6ensemble_dir` | Separate directory for ensemble-mean anomaly files |
| `reverse` | Negate anomalies (useful for validation runs) |

### Other
- `grib2netcdf.py` refactored with CLI argument parsing and config file support
- Python requirement lowered to `>=3.9`

## Test plan
- [ ] Run `write_intermediate.py` on a short date range and verify all 21 2D fields appear in the intermediate files
- [ ] Check `metgrid.exe` accepts the expanded field set (METGRID.TBL.ARW_PGW already lists these fields)
- [ ] Verify `siconc` is in 0–1 range in intermediate output
- [ ] Confirm grid spacing in intermediate files matches ERA5 header values
- [ ] Run `Calculate_CMIP6_Annual_cycle` on a model with unsorted time axis to confirm fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)
